### PR TITLE
Section for SSWG projects

### DIFF
--- a/catalog-info.json
+++ b/catalog-info.json
@@ -85,6 +85,26 @@
             }
           ],
           "title": "Vapor"
+        },
+        {
+          "content": [
+            {
+              "repositories": [
+                "http://github.com/apple/swift-nio.git",
+                "http://github.com/apple/swift-log.git",
+                "http://github.com/apple/swift-metrics.git",
+                "https://github.com/vapor/nio-postgres.git",
+                "https://github.com/mordil/swift-redis-nio-client.git",
+                "https://github.com/swift-server/async-http-client.git",
+                "https://github.com/kylebrowning/swift-nio-apns.git",
+                "https://github.com/apple/swift-statsd-client.git",
+                "https://github.com/MrLotU/SwiftPrometheus",
+              ],
+              "rows": 5,
+              "type": "small-list"
+            }
+          ],
+          "title": "SSWG — Server Side Working Group"
         }
       ],
       "image": "ImServer9",


### PR DESCRIPTION
The Server Side Working Group [recommends projects that can be trusted by the community](https://swift.org/server/#projects) and support best practices. Add a section with that list.

Not totally sure that `Title` is going to work correctly, but might be nice to define the acronym somewhere. If we have room for `Server Side Working Group` then we can just use that. Open to ideas!